### PR TITLE
Fixed variable name

### DIFF
--- a/01-Login/views/index.pug
+++ b/01-Login/views/index.pug
@@ -2,7 +2,7 @@ extends layout
 
 block content
   .w3-container
-    if loggedIn
+    if locals.user
       h4 You are logged in!
     else
       h4 You are not logged in! Please #[a(href="/login") Log In] to continue.


### PR DESCRIPTION
The "loggedIn" variable is not declared or assigned to anywhere, so the index.pug view always shows the user as not logged in. 

"locals.user" is what's declared in "lib/middleware/userInViews.", as well as used in "views/layout.pug".